### PR TITLE
Wifi esp8266 fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,4 +36,4 @@ build_flags = -D RELEASE_NAME=ESP8266
 [env:esp32thing]
 board = esp32thing
 platform = espressif32 @ 4.2.0
-build_flags = -D RELEASE_NAME=ESP32 -D LED_PIN=4
+build_flags = -D RELEASE_NAME=ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,16 +24,16 @@ lib_deps =
 	rstephan/ArtnetnodeWifi@^1.2.0
 
 [env:nodemcuv2]
-platform = espressif8266
+platform = espressif8266 @ 3.2.0
 board = nodemcuv2
 build_flags = -D RELEASE_NAME=ESP8266
 
 [env:d1_mini]
 board = d1_mini
-platform = espressif8266
+platform = espressif8266 @ 3.2.0
 build_flags = -D RELEASE_NAME=ESP8266
 
 [env:esp32thing]
 board = esp32thing
-platform = espressif32 @ 3.0.0
+platform = espressif32 @ 4.2.0
 build_flags = -D RELEASE_NAME=ESP32 -D LED_PIN=4

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -28,6 +28,7 @@ public:
 
         this->setupSPIFF();
 
+        WiFi.setHostname(hostName.c_str());
         // wifiManager.resetSettings();
 
         wifiManager.setDebugOutput(false);
@@ -59,7 +60,6 @@ public:
             Serial.printf("connected, IP: %s\n", WiFi.localIP().toString().c_str());
         } 
 
-        WiFi.setHostname(hostName.c_str());
 
         mqttHost = custom_mqtt_server.getValue();
         mqttUser = custom_mqtt_user.getValue();

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -25,11 +25,9 @@ class Configuration
 public:
     void setupWifiPortal(String hostName)
     {
-        WiFi.mode(WIFI_STA);
-        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE, INADDR_NONE);
-        WiFi.setHostname(hostName.c_str()); //define hostname
 
         this->setupSPIFF();
+
         // wifiManager.resetSettings();
 
         wifiManager.setDebugOutput(false);
@@ -47,8 +45,9 @@ public:
         wifiManager.setSaveConfigCallback(configCallback);
 
         Serial.print("Attempting WiFi connection... ");
-        bool res;
-        res = wifiManager.autoConnect(hostName.c_str());
+        
+        wifiManager.setHostname(hostName.c_str());
+        bool res = wifiManager.autoConnect(hostName.c_str(), NULL);
         if (!res)
         {
             Serial.println("failed! -> Reset");
@@ -59,6 +58,8 @@ public:
         {
             Serial.printf("connected, IP: %s\n", WiFi.localIP().toString().c_str());
         } 
+
+        WiFi.setHostname(hostName.c_str());
 
         mqttHost = custom_mqtt_server.getValue();
         mqttUser = custom_mqtt_user.getValue();

--- a/src/settings.h
+++ b/src/settings.h
@@ -10,7 +10,11 @@
 #define MQTT_PASSWORD "password"
 
 #ifndef LED_PIN
-#define LED_PIN D4
+    #ifdef ESP32
+    #define LED_PIN 4
+    #else
+    #define LED_PIN D4
+    #endif
 #endif
 #define NUM_LEDS 60
 #define LED_MAX_MILLIAMP 500


### PR DESCRIPTION
Auf dem ESP8266 führen die Änderungen von https://github.com/ProjektionTV/ProjektionFX/commit/5e2c1414c0bda276c23e7696d82ea421ba2c2adf insb. von 

```cpp
WiFi.mode(WIFI_STA);
WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE, INADDR_NONE);
WiFi.setHostname(hostName.c_str()); //define hostname
```

warum auch immer - dazu, dass der ESP zwar eine WiFi Verbindung aufbaut, aber sich anschließend nicht mit dem mqtt verbinden kann. Da nicht notwendig (imho) entfernt;  
Hostname nach dem Aufbau der Verbindung gesetzt. Funktioniert und wird im Router angezeigt

@ProjektionTV Bitte Einwand erheben, wenn du die 3 Einstellungen oben **unbedingt** benötigts?