### PR TITLE
Typo in type.

### DIFF
--- a/src/effect_quarter_beat_11.h
+++ b/src/effect_quarter_beat_11.h
@@ -11,7 +11,7 @@ public:
         static uint8_t oldQuarter = 0;
         FastLED.clearData();
         uint8_t quarter = beatInfo.animationFrame(1) / 250;
-        static u_int8_t hue = 0;
+        static uint8_t hue = 0;
         
         if(oldQuarter != quarter)
         {

--- a/src/effect_quarter_beat_11.h
+++ b/src/effect_quarter_beat_11.h
@@ -19,9 +19,9 @@ public:
             hue = random(255);
         }
 
-        for(int i=0; i<(NUM_LEDS/4);i++)
+        for(int i=0; i<(numLeds/4);i++)
         {
-            leds[i+(quarter*(NUM_LEDS/4))] = CHSV(hue, 255, 128);
+            leds[i+(quarter*(numLeds/4))] = CHSV(hue, 255, 128);
         }
     }
 };

--- a/src/effect_quarter_beat_14.h
+++ b/src/effect_quarter_beat_14.h
@@ -11,7 +11,7 @@ public:
         static uint8_t oldQuarter = 0;
         FastLED.clearData();
         uint8_t quarter = beatInfo.animationFrame(4) / 250;
-        static u_int8_t hue = 0;
+        static uint8_t hue = 0;
         
         if(oldQuarter != quarter)
         {

--- a/src/effect_quarter_beat_14.h
+++ b/src/effect_quarter_beat_14.h
@@ -19,9 +19,9 @@ public:
             hue = random(255);
         }
 
-        for(int i=0; i<(NUM_LEDS/4);i++)
+        for(int i=0; i<(numLeds/4);i++)
         {
-            leds[i+(quarter*(NUM_LEDS/4))] = CHSV(hue, 255, 128);
+            leds[i+(quarter*(numLeds/4))] = CHSV(hue, 255, 128);
         }
     }
 };

--- a/src/effects.h
+++ b/src/effects.h
@@ -10,7 +10,7 @@
 #include "effect_quarter_beat_14.h"
 
 
-#define EFFECTS_TOTAL 6
+#define EFFECTS_TOTAL 7
 
 // List of effects
 #define PFX_MOVING_DOT 0


### PR DESCRIPTION
Tippfehler im Variable-Typ.
Gibt es in Espressif 3.0.0 z.B. gar nicht und würde sich daher nicht mal bauen lassen.
In Version 4.2.0 gibt's den so aber :)
