### PR TITLE
[untested] remove the switch and defines in EffectsRunner class

### DIFF
--- a/src/effect_blink_rainbow.h
+++ b/src/effect_blink_rainbow.h
@@ -3,7 +3,7 @@
 class EffectBlinkRainbow : Effect
 {
 public:
-    static void run(BeatInfo& beatInfo, CRGB leds[], int numLeds)
+    static void run(BeatInfo& beatInfo, CRGBSet leds, int numLeds)
     {
         static unsigned long lastBeat;
         static unsigned long lastFade;

--- a/src/effects.h
+++ b/src/effects.h
@@ -9,55 +9,34 @@
 #include "effect_quarter_beat_11.h"
 #include "effect_quarter_beat_14.h"
 
-
-#define EFFECTS_TOTAL 6
-
-// List of effects
-#define PFX_MOVING_DOT 0
-#define PFX_BLINK_RAINBOW 1
-#define PFX_MOVING_DOT_SIMPLE 2
-#define PFX_BEATING_RAINBOW_STRIPES 3
-#define PFX_BREATH_CENTER 4
-#define PFX_QUARTER_BEAT_11 5
-#define PFX_QUARTER_BEAT_14 6
-
-
 extern CRGBArray<NUM_LEDS> leds;
+
+typedef void EffectFunction(BeatInfo&, CRGBSet, int);
 
 class EffectsRunner
 {
 private:
-    int currentEffect = PFX_QUARTER_BEAT_11;
+    int currentEffect = 0;
+    static constexpr const EffectFunction* effects[] = {
+        EffectMovingDot::run,
+        EffectBlinkRainbow::run,
+        EffectMovingDotSimple::run,
+        EffectBeatingRainbowStripes::run,
+        EffectBreathCenter::run,
+        EffectQuarterBeat11::run,
+        EffectQuarterBeat14::run,
+    };
+    int availableEffects(){
+        return sizeof(effects)/sizeof(*effects);
+    }
 
 public:
     void run()
     {
         Serial.printf("Current effect %d\n", currentEffect);
-        switch (currentEffect)
-        {
-        default:
-        case PFX_MOVING_DOT:
-            EffectMovingDot::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_BLINK_RAINBOW:
-            EffectBlinkRainbow::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_MOVING_DOT_SIMPLE:
-            EffectMovingDotSimple::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_BEATING_RAINBOW_STRIPES:
-            EffectBeatingRainbowStripes::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_BREATH_CENTER:
-            EffectBreathCenter::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_QUARTER_BEAT_11:
-            EffectQuarterBeat11::run(beatInfo, leds, NUM_LEDS);
-            break;
-        case PFX_QUARTER_BEAT_14:
-            EffectQuarterBeat14::run(beatInfo, leds, NUM_LEDS);
-            break;
-        }
+
+        EffectFunction* effectFunction = effects[currentEffect];
+        effectFunction(beatInfo, leds, NUM_LEDS);
     }
     int getCurrentEffect()
     {
@@ -65,15 +44,18 @@ public:
     }
     void setEffect(int effect)
     {
-        if (effect >= 0 && effect < EFFECTS_TOTAL)
+        if (effect >= 0 && effect < availableEffects())
+        {
             currentEffect = effect;
+        }
     }
     void nextEffect()
     {
-        currentEffect = (currentEffect + 1) % EFFECTS_TOTAL;
+        currentEffect = (currentEffect + 1) % availableEffects();
     }
 };
 
 EffectsRunner effectsRunner;
+constexpr const EffectFunction* EffectsRunner::effects[];
 
 #endif // EFFECTS_H__

--- a/src/effects.h
+++ b/src/effects.h
@@ -16,21 +16,28 @@ extern BeatInfo beatInfo;
 
 typedef void EffectFunction(BeatInfo&, CRGBSet, int);
 
+#define EFFECT_ENTRY(NAME) { NAME::run, #NAME }
+#define EMPTY_EFFECT_ENTRY() { nullptr, "empty" }
+struct EffectEntry{
+    EffectFunction* effectFunction;
+    const char* effectName;
+};
+
 class EffectsRunner
 {
 private:
     int currentEffect = 0;
-    static constexpr const EffectFunction* effects[] = {
-        EffectMovingDot::run,
-        EffectBlinkRainbow::run,
-        EffectMovingDotSimple::run,
-        EffectBeatingRainbowStripes::run,
-        EffectBreathCenter::run,
-        EffectQuarterBeat11::run,
-        EffectQuarterBeat14::run,
-        nullptr, // PFX_ILJA1
-        nullptr, // PFX_ILJA2
-        EffectStarburst::run,
+    static constexpr const EffectEntry effects[] = {
+        EFFECT_ENTRY(EffectMovingDot),
+        EFFECT_ENTRY(EffectBlinkRainbow),
+        EFFECT_ENTRY(EffectMovingDotSimple),
+        EFFECT_ENTRY(EffectBeatingRainbowStripes),
+        EFFECT_ENTRY(EffectBreathCenter),
+        EFFECT_ENTRY(EffectQuarterBeat11),
+        EFFECT_ENTRY(EffectQuarterBeat14),
+        EMPTY_EFFECT_ENTRY(), // PFX_ILJA1
+        EMPTY_EFFECT_ENTRY(), // PFX_ILJA2
+        EFFECT_ENTRY(EffectStarburst),
     };
     int availableEffects(){
         return sizeof(effects)/sizeof(*effects);
@@ -39,9 +46,9 @@ private:
 public:
     void run()
     {
-        Serial.printf("Current effect %d\n", currentEffect);
+        Serial.printf("Current effect %s(%d)\n", effects[currentEffect].effectName, currentEffect);
 
-        EffectFunction* effectFunction = effects[currentEffect];
+        EffectFunction* effectFunction = effects[currentEffect].effectFunction;
         if(effectFunction==nullptr){
             nextEffect();
         }else{
@@ -51,6 +58,10 @@ public:
     int getCurrentEffect()
     {
         return currentEffect;
+    }
+    const char* getCurrentEffectName()
+    {
+        return effects[currentEffect].effectName;
     }
     void setEffect(int effect)
     {
@@ -66,6 +77,6 @@ public:
 };
 
 EffectsRunner effectsRunner;
-constexpr const EffectFunction* EffectsRunner::effects[];
+constexpr const EffectEntry EffectsRunner::effects[];
 
 #endif // EFFECTS_H__


### PR DESCRIPTION
**NOT TESTED as i have currently no hardware available**

As the integration of new effects was "complex" and error prone, i tried to simplify it.
I removed the switch and the defines.
I replaced it with an static list of all effect run functions. The available effects are now calculated.

**A new effect should now only need to:**
- add the header file
- ~~add the "ClassName" with the "::run" postfix in the effects list~~
- add the ClassName via the EFFECT_ENTRY macro

**TESTED:**
- it compiles
- it runs in simulation https://wokwi.com/projects/331005073415995988

**NOT TESTED:**
- function availableEffects()
- the effect EffectBlinkRainbow
- on real hardware (not available at the moment)
