### PR TITLE
Korrektur für nahtlosen Übergang am Stipe-Ende (bzw. Ringanfang)

### DIFF
--- a/src/effect_movingdot.h
+++ b/src/effect_movingdot.h
@@ -25,7 +25,7 @@ public:
 
         for (int i = 0; i < length; i++)
         {
-            int p = min(numLeds-1, max(0, ledPos + i));
+            int p = (ledPos + i > numLeds - 1) ? ledPos - (numLeds - 1) + i : ledPos + i;
             leds[p] = color1;
             leds[p].fadeToBlackBy((length - i) * (255. / length));
         }
@@ -40,7 +40,7 @@ public:
         length = 10;
         for (int i = 0; i < length; i++)
         {
-            int p = min(numLeds-1, max(0, redLed + i));
+            int p = (redLed + i > numLeds - 1) ? redLed - (numLeds - 1) + i : redLed + i;
             leds[p] = blend(leds[redLed], CRGB::Red, 30);
             leds[p].fadeToBlackBy((i) * (255. / length));
         }


### PR DESCRIPTION
Korrektur des Effekts "Moving Dot" Da er, vor allem im Uhrenring, den Anfang überspringt und nicht nahtlos ist. 