### PR TITLE
add build infos to github workflow and print it at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@
 build_output
 
 src/settings_custom.h
+src/build_infos.h

--- a/pio-scripts/generate_build_infos.py
+++ b/pio-scripts/generate_build_infos.py
@@ -1,0 +1,45 @@
+Import("env", "projenv")
+import datetime
+import os
+
+# collect version time, hash and version
+buildtimestring = datetime.datetime.now().strftime("%d.%b.%Y %X")
+githash = os.environ.get('GITHUB_SHA') or "0"*40
+gitversion = os.environ.get('GITHUB_REF_NAME') or "manual build"
+
+# define content of build_infos.h
+build_infos_h = f"""
+#ifndef __build_infos__
+#define __build_infos__
+
+// !!! THIS FILE IS GENERATED - DO NOT MODIFY !!!
+
+class BuildInfos {{
+  public:
+    const char* getBuildTime(){{
+      return "{buildtimestring}";
+    }}
+    const char* getGitHash(){{
+      return "{githash}";
+    }}
+    const char* getGitVersion(){{
+      return "{gitversion}";
+    }}
+}};
+
+BuildInfos Build;
+
+#endif
+"""
+
+# write file
+with open('src/build_infos.h', 'w') as f:
+  f.write(build_infos_h)
+
+# output info on build console
+print("/-----------------------")
+print("| generated build infos")
+print(f"| {buildtimestring}")
+print(f"| {githash}")
+print(f"| {gitversion}")
+print("\\-----------------------")

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,9 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [scripts_defaults]
-extra_scripts = post:pio-scripts/rename-releases.py
+extra_scripts =
+	post:pio-scripts/rename-releases.py
+	post:pio-scripts/generate_build_infos.py
 
 [env]
 framework = arduino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <FastLED.h>
+#include <printBuildInfos.h>
 
 // #include <ESP8266WebServer.h>
 
@@ -25,6 +26,7 @@ void setup()
 {
 
   Serial.begin(115200);
+  printBuildInfos();
 
   config.setupWifiPortal("ProjektionFX");
 

--- a/src/printBuildInfos.h
+++ b/src/printBuildInfos.h
@@ -1,0 +1,31 @@
+#ifndef __PRINT_BUILD_INFOS__
+#define __PRINT_BUILD_INFOS__
+
+#include <Arduino.h>
+#include <build_infos.h> // will be created while building the project
+
+void printBuildInfos(){
+  Serial.println();
+  Serial.println();
+  Serial.println();
+
+  Serial.println("______                 _        _     _    _               ______ __   __");
+  Serial.println("| ___ \\               (_)      | |   | |  (_)              |  ___|\\ \\ / /");
+  Serial.println("| |_/ / _ __   ___     _   ___ | | __| |_  _   ___   _ __  | |_    \\ V / ");
+  Serial.println("|  __/ | '__| / _ \\   | | / _ \\| |/ /| __|| | / _ \\ | '_ \\ |  _|   /   \\ ");
+  Serial.println("| |    | |   | (_) |  | ||  __/|   < | |_ | || (_) || | | || |    / /^\\ \\");
+  Serial.println("\\_|    |_|    \\___/   | | \\___||_|\\_\\ \\__||_| \\___/ |_| |_|\\_|    \\/   \\/");
+  Serial.println("                     _/ |                                                ");
+  Serial.println("                    |__/                                                 ");
+
+  Serial.println();
+  Serial.println("https://github.com/ProjektionTV/ProjektionFX");
+
+  Serial.println();
+  Serial.printf("VERSION:    %s\n", Build.getGitVersion());
+  Serial.printf("GIT HASH:   %s\n", Build.getGitHash());
+  Serial.printf("BUILD DATE: %s\n", Build.getBuildTime());
+  Serial.println();
+}
+
+#endif


### PR DESCRIPTION
Hier mein Versuch, die Build Infos beim Starten der Firmware ausgeben zu lassen.
Leider hat der Versuch es primär über die plattform.ini zu machen nicht geklappt.

So wird nun über das Python Script generate_build_infos.py die Datei build_infos.h generiert.
Diese wird in printBuildInfos.h eingebunden.

Ich konnte es leider nicht mit einem Release komplett testen, aber die beim Release vergebenen Tags werden in der Variable GITHUB_REF_NAME von GitHub hinterlegt.

Ich hoffe es passt alles so. :)


Hier eine Beispielausgaben.

**Lokal**
```
______                 _        _     _    _               ______ __   __
| ___ \               (_)      | |   | |  (_)              |  ___|\ \ / /
| |_/ / _ __   ___     _   ___ | | __| |_  _   ___   _ __  | |_    \ V /
|  __/ | '__| / _ \   | | / _ \| |/ /| __|| | / _ \ | '_ \ |  _|   /   \
| |    | |   | (_) |  | ||  __/|   < | |_ | || (_) || | | || |    / /^\ \
\_|    |_|    \___/   | | \___||_|\_\ \__||_| \___/ |_| |_|\_|    \/   \/
                     _/ |
                    |__/

https://github.com/ProjektionTV/ProjektionFX

VERSION:    manual build
GIT HASH:   0000000000000000000000000000000000000000
BUILD DATE: 27.Nov.2022 19:41:24
```

**GitHub Build**
```
______                 _        _     _    _               ______ __   __
| ___ \               (_)      | |   | |  (_)              |  ___|\ \ / /
| |_/ / _ __   ___     _   ___ | | __| |_  _   ___   _ __  | |_    \ V /
|  __/ | '__| / _ \   | | / _ \| |/ /| __|| | / _ \ | '_ \ |  _|   /   \
| |    | |   | (_) |  | ||  __/|   < | |_ | || (_) || | | || |    / /^\ \
\_|    |_|    \___/   | | \___||_|\_\ \__||_| \___/ |_| |_|\_|    \/   \/
                     _/ |
                    |__/

https://github.com/ProjektionTV/ProjektionFX

VERSION:    v0.0.4
GIT HASH:   edeb431a20705fc6984c5a8f63106fbe6d40fca2
BUILD DATE: 27.Nov.2022 19:41:24
```